### PR TITLE
Add `Clear` method to `BaseAppender` (#19623)

### DIFF
--- a/src/include/duckdb.h
+++ b/src/include/duckdb.h
@@ -4573,6 +4573,15 @@ duckdb_appender_destroy to destroy the invalidated appender.
 DUCKDB_C_API duckdb_state duckdb_appender_flush(duckdb_appender appender);
 
 /*!
+Clears all buffered data from the appender without flushing it to the table. This discards any data that has been
+appended but not yet written. The appender can continue to be used after clearing.
+
+* @param appender The appender to clear.
+* @return `DuckDBSuccess` on success or `DuckDBError` on failure.
+*/
+DUCKDB_C_API duckdb_state duckdb_appender_clear(duckdb_appender appender);
+
+/*!
 Closes the appender by flushing all intermediate states and closing it for further appends. If flushing the data
 triggers a constraint violation or any other error, then all data is invalidated, and this function returns DuckDBError.
 Call duckdb_appender_error_data to obtain the error data followed by duckdb_appender_destroy to destroy the invalidated

--- a/src/include/duckdb/main/appender.hpp
+++ b/src/include/duckdb/main/appender.hpp
@@ -82,6 +82,8 @@ public:
 	DUCKDB_API void Flush();
 	//! Flush the changes made by the appender and close it. The appender cannot be used after this point
 	DUCKDB_API void Close();
+	//! Clears any appended data (without flushing).
+	DUCKDB_API void Clear();
 	//! Returns the active types of the appender.
 	const vector<LogicalType> &GetActiveTypes() const;
 

--- a/src/include/duckdb/main/capi/extension_api.hpp
+++ b/src/include/duckdb/main/capi/extension_api.hpp
@@ -475,6 +475,7 @@ typedef struct {
 	duckdb_state (*duckdb_appender_create_query)(duckdb_connection connection, const char *query, idx_t column_count,
 	                                             duckdb_logical_type *types, const char *table_name,
 	                                             const char **column_names, duckdb_appender *out_appender);
+	duckdb_state (*duckdb_appender_clear)(duckdb_appender appender);
 	// New arrow interface functions
 
 	duckdb_error_data (*duckdb_to_arrow_schema)(duckdb_arrow_options arrow_options, duckdb_logical_type *types,
@@ -1057,6 +1058,7 @@ inline duckdb_ext_api_v1 CreateAPIv1() {
 	result.duckdb_append_default_to_chunk = duckdb_append_default_to_chunk;
 	result.duckdb_appender_error_data = duckdb_appender_error_data;
 	result.duckdb_appender_create_query = duckdb_appender_create_query;
+	result.duckdb_appender_clear = duckdb_appender_clear;
 	result.duckdb_to_arrow_schema = duckdb_to_arrow_schema;
 	result.duckdb_data_chunk_to_arrow = duckdb_data_chunk_to_arrow;
 	result.duckdb_schema_from_arrow = duckdb_schema_from_arrow;

--- a/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_append_functions.json
+++ b/src/include/duckdb/main/capi/header_generation/apis/v1/unstable/new_append_functions.json
@@ -4,6 +4,7 @@
     "entries": [
         "duckdb_append_default_to_chunk",
         "duckdb_appender_error_data",
-        "duckdb_appender_create_query"
+        "duckdb_appender_create_query",
+        "duckdb_appender_clear"
     ]
 }

--- a/src/include/duckdb/main/capi/header_generation/functions/appender.json
+++ b/src/include/duckdb/main/capi/header_generation/functions/appender.json
@@ -211,6 +211,23 @@
             }
         },
         {
+            "name": "duckdb_appender_clear",
+            "return_type": "duckdb_state",
+            "params": [
+                {
+                    "type": "duckdb_appender",
+                    "name": "appender"
+                }
+            ],
+            "comment": {
+                "description": "Clears all buffered data from the appender without flushing it to the table. This discards any data that has been appended but not yet written. The appender can continue to be used after clearing.\n\n",
+                "param_comments": {
+                    "appender": "The appender to clear."
+                },
+                "return_value": "`DuckDBSuccess` on success or `DuckDBError` on failure."
+            }
+        },
+        {
             "name": "duckdb_appender_close",
             "return_type": "duckdb_state",
             "params": [

--- a/src/include/duckdb_extension.h
+++ b/src/include/duckdb_extension.h
@@ -544,6 +544,7 @@ typedef struct {
 	duckdb_state (*duckdb_appender_create_query)(duckdb_connection connection, const char *query, idx_t column_count,
 	                                             duckdb_logical_type *types, const char *table_name,
 	                                             const char **column_names, duckdb_appender *out_appender);
+	duckdb_state (*duckdb_appender_clear)(duckdb_appender appender);
 #endif
 
 // New arrow interface functions
@@ -1163,6 +1164,7 @@ typedef struct {
 // Version unstable_new_append_functions
 #define duckdb_appender_create_query   duckdb_ext_api.duckdb_appender_create_query
 #define duckdb_appender_error_data     duckdb_ext_api.duckdb_appender_error_data
+#define duckdb_appender_clear          duckdb_ext_api.duckdb_appender_clear
 #define duckdb_append_default_to_chunk duckdb_ext_api.duckdb_append_default_to_chunk
 
 // Version unstable_new_arrow_functions

--- a/src/main/appender.cpp
+++ b/src/main/appender.cpp
@@ -619,4 +619,14 @@ void BaseAppender::Close() {
 	}
 }
 
+void BaseAppender::Clear() {
+	chunk.Reset();
+
+	if (collection) {
+		collection->Reset();
+	}
+
+	column = 0;
+}
+
 } // namespace duckdb

--- a/src/main/capi/appender-c.cpp
+++ b/src/main/capi/appender-c.cpp
@@ -318,6 +318,10 @@ duckdb_state duckdb_appender_flush(duckdb_appender appender_p) {
 	return duckdb_appender_run_function(appender_p, [&](BaseAppender &appender) { appender.Flush(); });
 }
 
+duckdb_state duckdb_appender_clear(duckdb_appender appender_p) {
+	return duckdb_appender_run_function(appender_p, [&](BaseAppender &appender) { appender.Clear(); });
+}
+
 duckdb_state duckdb_appender_close(duckdb_appender appender_p) {
 	return duckdb_appender_run_function(appender_p, [&](BaseAppender &appender) { appender.Close(); });
 }

--- a/test/api/capi/test_capi_appender.cpp
+++ b/test/api/capi/test_capi_appender.cpp
@@ -1252,3 +1252,100 @@ TEST_CASE("Test upserting using the C API", "[capi]") {
 
 	tester.Cleanup();
 }
+
+TEST_CASE("Test clear appender data in C API", "[capi]") {
+	CAPITester tester;
+	duckdb::unique_ptr<CAPIResult> result;
+	duckdb_state status;
+
+	REQUIRE(tester.OpenDatabase(nullptr));
+
+	// create a table and insert initial data
+	REQUIRE_NO_FAIL(tester.Query("CREATE TABLE integers(i INTEGER)"));
+	REQUIRE_NO_FAIL(tester.Query("INSERT INTO integers VALUES (1)"));
+
+	// create appender and append many rows
+	duckdb_appender appender;
+	status = duckdb_appender_create(tester.connection, nullptr, "integers", &appender);
+	REQUIRE(status == DuckDBSuccess);
+	REQUIRE(duckdb_appender_error(appender) == nullptr);
+
+	// We will append rows to reach more than the maximum chunk size
+	// (DEFAULT_FLUSH_COUNT will always be more than a chunk size),
+	// so we will make sure that also the collection is being cleared.
+	// We use the DEFAULT_FLUSH_COUNT so we won't flush before calling the `Clear`
+	constexpr auto rows_to_append = BaseAppender::DEFAULT_FLUSH_COUNT - 10;
+
+	// append a bunch of values that should be cleared
+	for (idx_t i = 0; i < rows_to_append; i++) {
+		status = duckdb_appender_begin_row(appender);
+		REQUIRE(status == DuckDBSuccess);
+		status = duckdb_append_int32(appender, 999);
+		REQUIRE(status == DuckDBSuccess);
+		status = duckdb_appender_end_row(appender);
+		REQUIRE(status == DuckDBSuccess);
+	}
+
+	// clear all buffered data without flushing
+	status = duckdb_appender_clear(appender);
+	REQUIRE(status == DuckDBSuccess);
+
+	// close the appender (should not write the cleared data)
+	status = duckdb_appender_close(appender);
+	REQUIRE(status == DuckDBSuccess);
+
+	// verify that only the initial data exists (the 2000 rows were cleared)
+	result = tester.Query("SELECT SUM(i)::BIGINT FROM integers");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<int64_t>(0, 0) == 1);
+
+	// destroy the appender
+	status = duckdb_appender_destroy(&appender);
+	REQUIRE(status == DuckDBSuccess);
+
+	// test that appender can be used after clear
+	status = duckdb_appender_create(tester.connection, nullptr, "integers", &appender);
+	REQUIRE(status == DuckDBSuccess);
+
+	// append a few rows
+	for (idx_t i = 0; i < 5; i++) {
+		status = duckdb_appender_begin_row(appender);
+		REQUIRE(status == DuckDBSuccess);
+		status = duckdb_append_int32(appender, 42);
+		REQUIRE(status == DuckDBSuccess);
+		status = duckdb_appender_end_row(appender);
+		REQUIRE(status == DuckDBSuccess);
+	}
+
+	// clear again
+	status = duckdb_appender_clear(appender);
+	REQUIRE(status == DuckDBSuccess);
+
+	// append new data after clear
+	for (idx_t i = 0; i < 3; i++) {
+		status = duckdb_appender_begin_row(appender);
+		REQUIRE(status == DuckDBSuccess);
+		status = duckdb_append_int32(appender, 100);
+		REQUIRE(status == DuckDBSuccess);
+		status = duckdb_appender_end_row(appender);
+		REQUIRE(status == DuckDBSuccess);
+	}
+
+	// flush this time to write the new data
+	status = duckdb_appender_flush(appender);
+	REQUIRE(status == DuckDBSuccess);
+
+	// close
+	status = duckdb_appender_close(appender);
+	REQUIRE(status == DuckDBSuccess);
+
+	// verify: initial 1 + new 3 rows = 301 total
+	result = tester.Query("SELECT SUM(i)::BIGINT FROM integers");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<int64_t>(0, 0) == 301);
+
+	status = duckdb_appender_destroy(&appender);
+	REQUIRE(status == DuckDBSuccess);
+
+	tester.Cleanup();
+}


### PR DESCRIPTION
## Summary
This Pull Request adds a new `Clear` function to the `Appender`, enabling the clearing of pending data without flushing.

### Motivation
When closing an `Appender`, a `Flush` will also be triggered. However, sometimes, we wouldn't want to flush the data, for instance, when there is a problem with the flushing.
In such case, we would sometimes prefer to only clear the appender and close it.
We enable this capability by exposing the `Clear` method.

### Changes
- `Clear` method
- Added a test for verifying the `Clear` method correctly clears data and that the next `Flush` won't write the data that should have been cleared.
- Added a test that simulates a Heavy `QueryAppender` that should be interrupted and then cleared, before being closed, to ensure the `Clear` method actually "enables" the `Close` method for such scenarios.

### Upcoming Next
A PR for exposing the `Clear` method through the C-API.