### PR TITLE
backport 20868

### DIFF
--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -554,7 +554,13 @@ unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(QueryContext c
 	}
 	if (temporary_directory.handle->GetTempFile().HasTemporaryBuffer(id)) {
 		// This is a block that was offloaded to a regular .tmp file, the file contains blocks of a fixed size
-		return temporary_directory.handle->GetTempFile().ReadTemporaryBuffer(context, id, std::move(reusable_buffer));
+		auto buffer =
+		    temporary_directory.handle->GetTempFile().ReadTemporaryBuffer(context, id, std::move(reusable_buffer));
+
+		// Decrement evicted size.
+		evicted_data_per_tag[uint8_t(tag)] -= buffer->AllocSize();
+
+		return buffer;
 	}
 
 	// This block contains data of variable size so we need to open it and read it to get its size.
@@ -590,6 +596,10 @@ unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(QueryContext c
 
 	// Delete the file and return the buffer.
 	DeleteTemporaryFile(block.GetMemory());
+
+	// Decrement evicted size.
+	evicted_data_per_tag[uint8_t(tag)] -= buffer->AllocSize();
+
 	return buffer;
 }
 

--- a/test/sql/outofcore/evicted_memory_bytes_updates.test_slow
+++ b/test/sql/outofcore/evicted_memory_bytes_updates.test_slow
@@ -1,0 +1,22 @@
+# name: test/sql/outofcore/evicted_memory_bytes_updates.test_slow
+# group: [outofcore]
+
+statement ok
+SET threads=1;
+
+statement ok
+SET temp_directory='__TEST_DIR__/test_temp_dir'
+
+statement ok
+SET memory_limit='100MB';
+
+statement ok
+create table range as from range(1_000_000);
+
+statement ok
+select any_value(range) from range a group by range % 1000000;
+
+query II
+SELECT memory_usage_bytes, temporary_storage_bytes FROM duckdb_memory() WHERE tag = 'HASH_TABLE';
+----
+0	0


### PR DESCRIPTION
Backports https://github.com/duckdb/duckdb/pull/20868, note I bumped the memory limit up to 100MB, perhaps there are some memory inefficiencies in 1.4, but the test doesn't pass with 50MB in v1.4. Either away it is in the same magnitude so I think the test still makes sense (more exact number it worked at was 85MB). 